### PR TITLE
Fix parameters for \author

### DIFF
--- a/mwe-de.tex
+++ b/mwe-de.tex
@@ -2,7 +2,7 @@
 \bibliography{LNI-examples.bib}
 \begin{document}
 \title{Titel}
-\author{Vorname Nachname}
+\author{Vorname Nachname}{}{}
 \maketitle
 \begin{abstract}
 Text

--- a/mwe-en.tex
+++ b/mwe-en.tex
@@ -4,7 +4,7 @@
 \bibliography{LNI-examples.bib}
 \begin{document}
 \title{Title}
-\author{Firstname Lastname}
+\author{Firstname Lastname}{}{}
 \maketitle
 \begin{abstract}
 Text


### PR DESCRIPTION
With the [1.8 release](https://github.com/gi-ev/LNI/blob/main/CHANGELOG.md#18---2023-11-26), the syntax for `\author` has changed.